### PR TITLE
Tidy notes_folder configuration

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -940,24 +940,22 @@ Please drop the folder which contains your notes into the User Configuration tab
 				<key>default</key>
 				<string></string>
 				<key>filtermode</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>placeholder</key>
 				<string>Please pick your folder...</string>
 				<key>required</key>
 				<true/>
 			</dict>
 			<key>description</key>
-			<string></string>
+			<string>Where you keep your notes in Notable.</string>
 			<key>label</key>
-			<string>The folder where you keep your notes in Notable.</string>
+			<string>Notes Folder</string>
 			<key>type</key>
 			<string>filepicker</string>
 			<key>variable</key>
 			<string>notes_location</string>
 		</dict>
 	</array>
-	<key>variablesdontexport</key>
-	<array/>
 	<key>version</key>
 	<string>0.9-beta</string>
 	<key>webaddress</key>


### PR DESCRIPTION
This gives more space to read the folder’s path and limites the File Picker to folders only.

<img width="532" alt="image" src="https://user-images.githubusercontent.com/1699443/196240815-10665d46-5840-438a-807b-b1ea090546ca.png">
