### PR TITLE
Update bundle identifier

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>bundleid</key>
-	<string>com.alfredapp.notable</string>
+	<string>app.alfred.kostyafarber.notable</string>
 	<key>category</key>
 	<string>Tools</string>
 	<key>connections</key>


### PR DESCRIPTION
Bundle identifiers are supposed to follow a specific pattern. We figured that `app.alfred.username.workflowname` is a good one for people who don’t have a domain name but have a workflow in the Gallery. `com.alfredapp.` is to be used in official workflows since it’s the domain of the Alfred app itself.

You don’t have to worry about the changed identifier updates-wise, as Alfred and the Gallery will take the change into account.